### PR TITLE
using colors for output

### DIFF
--- a/src/cmdstan/callbacks/color_interrupt.hpp
+++ b/src/cmdstan/callbacks/color_interrupt.hpp
@@ -1,0 +1,131 @@
+#ifndef CMDSTAN_CALLBACKS_COLOR_INTERRUPT_HPP
+#define CMDSTAN_CALLBACKS_COLOR_INTERRUPT_HPP
+
+#include <stan/callbacks/interrupt.hpp>
+#include <cstdlib>
+#include <cmath>
+#include <random>
+#include <ctime>
+
+namespace cmdstan {
+namespace callbacks {
+
+  class color_interrupt : public stan::callbacks::interrupt {
+  public:
+    color_interrupt(const int N_warmup, const int N_draws)
+      : N_warmup_(N_warmup), N_draws_(N_draws), N_total_(N_warmup + N_draws),
+	iteration_(0),
+	start_ms_(static_cast<long int>(std::time(nullptr))),
+	g_(start_ms_), flip_(0.21),
+	game_num_(std::uniform_int_distribution<int>(1,10000)(g_)),
+	N_(-1) {
+      stops_ = create_stops(N_warmup_, N_draws_, 6);
+    }
+
+    void operator()() {
+      if (iteration_ == 0) {
+	std::cout << "CmdStan " << game_num_ << " " << std::flush;
+      }
+      iteration_++;
+
+      if (N_ == -1 && iteration_ == stops_[0]) {
+	long int current_ms = static_cast<long int>(std::time(nullptr));
+	if (current_ms - start_ms_ < 1000) {
+	  int p = std::uniform_int_distribution<int>(1,60)(g_);
+	  if (p < 5)
+	    N_ = 1;
+	  else if (p < 15)
+	    N_ = 2;
+	  else if (p < 25)
+	    N_ = 3;
+	  else if (p < 35)
+	    N_ = 4;
+	  else if (p < 45)
+	    N_ = 5;
+	  else
+	    N_ = 6;
+	} else {
+	  N_ = 6;
+	}
+	std::cout << N_ << "/6" << std::endl << std::endl;
+
+	stops_ = create_stops(N_warmup_, N_draws_, N_);
+      }
+
+      int* stop_location = std::find(&stops_[0], &stops_[0] + 5, iteration_);
+      if (stop_location != (&stops_[0] + 5)) {
+	int stop_number = stop_location - &stops_[0] + 1;
+	//std::cout << "stopping at iteration_ = " << iteration_ << std::endl;
+	create_row_colors(stop_number, N_, colors_);
+	for (int n = 0; n < 5; n++) {
+	  std::cout << colors_[n];
+	}
+	std::cout << std::endl;
+      }
+
+      if (iteration_ == N_total_) {
+	for (int n = 0; n < 5; n++) {
+	  std::cout << grn_;
+	}
+	std::cout << std::endl;
+      }
+    }
+
+  private:
+    const char grn_[5] { '\xF0', '\x9F', '\x9F', '\xA9', 0};
+    const char yel_[5] { '\xF0', '\x9F', '\x9F', '\xA8', 0};
+    const char gry_[4] { '\xE2', '\xAC', '\x9C', 0};
+
+    const int N_warmup_;
+    const int N_draws_;
+    const int N_total_;
+    int iteration_;
+    const char *colors_[5];
+
+    const long int start_ms_;
+    std::default_random_engine g_;
+    std::bernoulli_distribution flip_;
+    const int game_num_;
+
+    int N_;
+    std::vector<int> stops_;
+
+    std::vector<int> create_stops(int N_warmup, int N_draws, int N_stops) {
+      int N_total = N_warmup + N_draws;
+      std::vector<int> stops{ -1, -1, -1, -1, -1 };
+
+      for (int n = 0; n < (N_stops - 1); n++) {
+	stops[n] = ceil((n + 1.0) * N_total / N_stops);
+      }
+      return stops;
+    }
+
+    void create_row_colors(const int stop_number, const int N, const char *colors[5]) {
+      // init to all gray
+      for (int n = 0; n < 5; n++)
+	colors[n] = &gry_[0];
+
+      for (int n = 0; n < 5; ++n) {
+	// color green or yellow
+	if (n < 5 * stop_number / N) {
+	  if (flip_(g_)) {
+	    colors[n] = &yel_[0];
+	  } else {
+	    colors[n] = &grn_[0];
+	  }
+	} else {
+	  if (flip_(g_)) {
+	    colors[n] = &yel_[0];
+	  } else {
+	    colors[n] = &gry_[0];
+	  }
+	}
+      }
+      
+      std::shuffle(&colors[0], &colors[5], g_);
+    }
+  };
+
+}  // namespace callbacks
+}  // namespace cmdstan
+#endif

--- a/src/cmdstan/command.hpp
+++ b/src/cmdstan/command.hpp
@@ -21,6 +21,7 @@
 #include <cmdstan/write_profiling.hpp>
 #include <cmdstan/write_stan.hpp>
 #include <cmdstan/write_stan_flags.hpp>
+#include <cmdstan/callbacks/color_interrupt.hpp>
 #include <stan/callbacks/interrupt.hpp>
 #include <stan/callbacks/logger.hpp>
 #include <stan/callbacks/stream_logger.hpp>
@@ -416,6 +417,7 @@ int command(int argc, const char *argv[]) {
   stan::callbacks::writer init_writer;
   stan::callbacks::interrupt interrupt;
 
+
   //////////////////////////////////////////////////
   //                Initialize Model              //
   //////////////////////////////////////////////////
@@ -516,9 +518,11 @@ int command(int argc, const char *argv[]) {
     parser.print(diagnostic_writers[i]);
   }
 
-  int refresh
-      = dynamic_cast<int_argument *>(parser.arg("output")->arg("refresh"))
-            ->value();
+  int refresh = 0;
+  std::cout << "[INFO] Ignorning refresh parameter" << std::endl;
+  //= dynamic_cast<int_argument *>(parser.arg("output")->arg("refresh"))
+  //->value();
+  
 
   // Read initial parameter values or user-specified radius
   std::string init
@@ -690,6 +694,15 @@ int command(int argc, const char *argv[]) {
     bool adapt_engaged
         = dynamic_cast<bool_argument *>(adapt->arg("engaged"))->value();
 
+    cmdstan::callbacks::color_interrupt interrupt(num_warmup, num_samples);
+    std::cout << "\n\n\n"
+	      << "############################################################\n"
+	      << "## Welcome to the CmdStan v" << stan::MAJOR_VERSION << "."
+	      << stan::MINOR_VERSION << "."
+	      << stan::PATCH_VERSION << " with color outputs      ##\n"
+	      << "############################################################\n"
+	      << std::endl;
+    
     if (model.num_params_r() == 0 || algo->value() == "fixed_param") {
       if (algo->value() != "fixed_param")
         info(


### PR DESCRIPTION
This is the one, I think. It looks like this:

```
############################################################
## Welcome to the CmdStan v2.29.1 with color outputs      ##
############################################################


Gradient evaluation took 2e-06 seconds
1000 transitions using 10 leapfrog steps per transition would take 0.02 seconds.
Adjust your expectations accordingly!


CmdStan 1081 6/6

⬜⬜⬜⬜⬜
⬜⬜⬜⬜🟩
🟩⬜⬜🟩🟨
⬜🟩🟨🟩⬜
🟩🟩🟩🟩🟨
🟩🟩🟩🟩🟩
```

and like
```
CmdStan 713 3/6

🟨⬜⬜⬜🟩
🟨🟩🟩🟩⬜
🟩🟩🟩🟩🟩
```